### PR TITLE
Display Fahrenheit When user-settings temperature Fahrenheit

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -13,6 +13,11 @@ clock.initialize("minutes", data => {
 
 newfile.initialize(data => {
   // fresh weather file received
+
+  // if user-settings temperature == F and the data.unit == Celsius then we convert to Fahrenheit
+  // This use only if the getWeatherData() function we use without optional parameter.
+  data = units.temperature == "F" ? tempCFConv(data): data;
+
   details.text = `It's ${data.temperature}\u00B0 ${data.unit} and ${data.condition} in ${data.location}`;
   clock.tick();
 });

--- a/app/index.js
+++ b/app/index.js
@@ -2,7 +2,8 @@ import document from "document";
 
 import * as clock from "./clock";
 import * as newfile from "./newfile";
-import { tempCFConv } from "../common/utils";
+import { toFahrenheit } from "../common/utils";
+import { units } from "user-settings";
 
 const time = document.getElementById("time");
 const details = document.getElementById("details");
@@ -15,9 +16,9 @@ clock.initialize("minutes", data => {
 newfile.initialize(data => {
   // fresh weather file received
 
-  // if user-settings temperature == F and the data.unit == Celsius then we convert to Fahrenheit
-  // This use only if the getWeatherData() function we use without optional parameter.
-  data = units.temperature == "F" ? tempCFConv(data): data;
+  // If the user-settings temperature == F and the result data.unit == Celsius then we convert to Fahrenheit
+  // Use only if the getWeatherData() function you use without optional parameter.
+  data = units.temperature === "F" ? toFahrenheit(data): data;
 
   details.text = `It's ${data.temperature}\u00B0 ${data.unit} and ${data.condition} in ${data.location}`;
   clock.tick();

--- a/app/index.js
+++ b/app/index.js
@@ -2,6 +2,7 @@ import document from "document";
 
 import * as clock from "./clock";
 import * as newfile from "./newfile";
+import { tempCFConv } from "../common/utils";
 
 const time = document.getElementById("time");
 const details = document.getElementById("details");

--- a/common/utils.js
+++ b/common/utils.js
@@ -13,9 +13,9 @@ export function zeroPad(i) {
 * Convert Celsius to Fahrenheit
 * @param {object} data - WeatherData -
 */
-export function tempCFConv(data) {
+export function toFahrenheit(data) {
   
-  if (data.unit.toLowerCase() == "celsius") {
+  if (data.unit.toLowerCase() === "celsius") {
      data.temperature =  Math.round((data.temperature * 1.8)+32);
      data.unit = "Fahrenheit";
   }

--- a/common/utils.js
+++ b/common/utils.js
@@ -8,3 +8,19 @@ export function zeroPad(i) {
   }
   return i;
 }
+
+/**
+* Convert Celsius to Fahrenheit
+* @param {object} data - WeatherData -
+*/
+export function tempCFConv(data) {
+  
+  if (data.unit.toLowerCase() == "celsius") {
+     data.temperature =  Math.round((data.temperature * 1.8)+32);
+     data.unit = "Fahrenheit";
+  }
+  
+  return data
+}
+
+


### PR DESCRIPTION
In the companion, if we request the weather data without optional parameter (TemperatureUnit) then the response
data.unit == "Celsius" even if the user temperature is set to Fahrenheit.

solution: check the user-settings temperature parameter and if this F then we need convert the Celsius to Fahrenheit
